### PR TITLE
feat: ask for manage_community permission

### DIFF
--- a/src/deezer_oauth/client.py
+++ b/src/deezer_oauth/client.py
@@ -30,6 +30,7 @@ class OAuthDancer:
                         "basic_access",
                         "email",
                         "manage_library",
+                        "manage_community",
                         "delete_library",
                         "listening_history",
                     ]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -11,7 +11,7 @@ class TestOAuthDancer:
             "https://connect.deezer.com/oauth/auth.php"
             "?app_id=1234"
             "&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Foauth%2Freturn"
-            "&perms=basic_access%2Cemail%2Cmanage_library"
+            "&perms=basic_access%2Cemail%2Cmanage_library%2Cmanage_community"
             "%2Cdelete_library%2Clistening_history"
         )
 


### PR DESCRIPTION
Ask for the `manage_community` permission (see [Deezer API, permissions](https://developers.deezer.com/api/permissions)). This allows to manage user's friends:
- get the followers 
- get, add or remove a following
