### PR TITLE
ci: switch to Python 3.12 final

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
-          - "3.12-dev"
+          - "3.12"
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos